### PR TITLE
Bump nixpkgs to 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,13 +5,13 @@
       "locked": {
         "lastModified": 1761588595,
         "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -18,16 +18,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753115646,
-        "narHash": "sha256-yLuz5cz5Z+sn8DRAfNkrd2Z1cV6DaYO9JMrEz4KZo/c=",
+        "lastModified": 1764522689,
+        "narHash": "sha256-SqUuBFjhl/kpDiVaKLQBoD8TLD+/cTUzzgVFoaHrkqY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "92c2e04a475523e723c67ef872d8037379073681",
+        "rev": "8bb5646e0bed5dbd3ab08c7a7cc15b75ab4e1d0f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs         .url = "github:NixOS/nixpkgs/nixos-25.11";
-    flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
+    flake-compat = { url = "github:NixOS/flake-compat"; flake = false; };
     nosys           .url = "github:divnix/nosys";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "An abstraction layer on top of Geant4";
 
   inputs = {
-    nixpkgs         .url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs         .url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
     nosys           .url = "github:divnix/nosys";
   };


### PR DESCRIPTION
No surprises when running locally. 

However, I am getting increasingly annoyed by #195.

Ideally we would like to know that the bootstrapped project is not broken by the changes in this PR. However, the flake always points to the master branch, which prevents testing this.
For now, I have checked that nothing breaks by hand:

```
nix run "/path/to/nain4?rev=HASH"#bootstrap-client-project here name description
cd here
sed -i "s/github:jacg\/nain4/\path\/to\/nain4?rev=HASH/g" # replace nain4 path
nix develop -c just test
nix develop -c just run -n 1
```